### PR TITLE
Fixed post-H scene idle animations after kissing.

### DIFF
--- a/CyuVR/Cyu.cs
+++ b/CyuVR/Cyu.cs
@@ -77,6 +77,7 @@ namespace Bero.CyuVR
 		internal static bool isInOrgasm;
 		internal static HFlag.FinishKind origFinishFlag;
 		private string prevAnimation;
+		internal bool preventPrevAnimationSwap;
 
 		public bool IsKiss { get; private set; }
 
@@ -200,7 +201,11 @@ namespace Bero.CyuVR
 
 				// Save the current animation so that we can return to it after kissing is over.
 				// This allows us to retain facial expressions after going back to idle, e.g., post-orgasm expressions.
-				prevAnimation = flags.nowAnimStateName;
+				if (CyuLoaderVR.OrgasmAfterKiss.Value)
+				{
+					prevAnimation = flags.nowAnimStateName;
+					preventPrevAnimationSwap = false;
+				}
 
 				if (flags.mode == HFlag.EMode.aibu)
 				{
@@ -365,7 +370,8 @@ namespace Bero.CyuVR
 			}
 
 			// Return to the previous animation after the player finishes kissing.
-			aibu.SetPlay(prevAnimation);
+			if(CyuLoaderVR.OrgasmAfterKiss.Value && !preventPrevAnimationSwap)
+				aibu.SetPlay(prevAnimation);
 
 			kissPhase = Phase.Disengaging;
 			for (; ; )

--- a/CyuVR/Cyu.cs
+++ b/CyuVR/Cyu.cs
@@ -1,11 +1,10 @@
-using ChaCustom;
-using Harmony;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
 using UnityEngine;
+using Harmony;
 
 namespace Bero.CyuVR
 {
@@ -77,6 +76,7 @@ namespace Bero.CyuVR
 		internal object[] touchOrder = new object[2];
 		internal static bool isInOrgasm;
 		internal static HFlag.FinishKind origFinishFlag;
+		private string prevAnimation;
 
 		public bool IsKiss { get; private set; }
 
@@ -197,6 +197,10 @@ namespace Bero.CyuVR
 					IsKiss = false;
 					return;
 				}
+
+				// Save the current animation so that we can return to it after kissing is over.
+				// This allows us to retain facial expressions after going back to idle, e.g., post-orgasm expressions.
+				prevAnimation = flags.nowAnimStateName;
 
 				if (flags.mode == HFlag.EMode.aibu)
 				{
@@ -360,6 +364,9 @@ namespace Bero.CyuVR
 
 			}
 
+			// Return to the previous animation after the player finishes kissing.
+			aibu.SetPlay(prevAnimation);
+
 			kissPhase = Phase.Disengaging;
 			for (; ; )
 			{
@@ -382,6 +389,7 @@ namespace Bero.CyuVR
 			yield return null;
 			kissPhase = Phase.None;
 			kissing = false;
+
 			yield break;
 		}
 

--- a/CyuVR/CyuLoaderVR.cs
+++ b/CyuVR/CyuLoaderVR.cs
@@ -1,10 +1,11 @@
 ﻿using BepInEx;
-using Harmony;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using System.ComponentModel;
+using Harmony;
+using BepInEx4;
 
 namespace Bero.CyuVR
 {
@@ -62,6 +63,10 @@ namespace Bero.CyuVR
 		[DisplayName("Player Mouth Offset")]
 		[Description("Negative vertical offset to player's mouth (increase this value to make your own mouth lower)")]
 		public static ConfigWrapper<float> MouthOffset { get; private set; }	
+
+		[DisplayName("Sustain Orgasm After Kiss")]
+		[Description("If enabled, the girl will remain in orgasm after kissing. Groping the girl will end her orgasm.")]
+		public static ConfigWrapper<bool> OrgasmAfterKiss { get; private set; }
 	
 		///
 		//////////////////// Keyboard Shortcuts /////////////////////////// 
@@ -91,6 +96,7 @@ namespace Bero.CyuVR
 			KissMotionSpeed = new ConfigWrapper<float>(nameof(KissMotionSpeed), this, 0.1f);
 			MouthMovement = new ConfigWrapper<Cyu.FrenchMode>(nameof(MouthMovement), this, Cyu.FrenchMode.Auto);
 			MouthOffset = new ConfigWrapper<float>(nameof(MouthOffset), this, 0.12f);
+			OrgasmAfterKiss = new ConfigWrapper<bool>(nameof(OrgasmAfterKiss), this, false);
 			
 			PluginToggleKey = new SavedKeyboardShortcut(nameof(PluginToggleKey), this, new KeyboardShortcut(KeyCode.None));
 

--- a/CyuVR/Hooks.cs
+++ b/CyuVR/Hooks.cs
@@ -232,6 +232,11 @@ namespace Bero.CyuVR
 			if (!cyu || cyu.flags.mode != HFlag.EMode.aibu)
 				return;
 
+			// If OrgasmAfterKiss is enabled, then we need to ensure that we do not revert back to an incorrect animation state if the girl
+			// is being groped while kissing (see https://github.com/MayouKurayami/KK_CyuVR/pull/1#issuecomment-790853354).
+			if(CyuLoaderVR.OrgasmAfterKiss.Value)
+				CyuLoaderVR.mainCyu.preventPrevAnimationSwap = true;
+
 			//If the last position in the array is filled, move it back one position and fill the last position with the current action
 			//This ensures the last touched body part is always tracked in the last position of the array, 
 			//while the first position tracks any other body part that is being touched concurrently 


### PR DESCRIPTION
Originally, after kissing, characters would return to their default idle state. This led to some strange transitions, particularly after orgasms, where characters would switch abruptly to their default idle after kissing. This commit ensures that characters always return to their previous animation following a kiss.